### PR TITLE
sqltest: fix SkipTeardown to reduce false positives and add SerupVersion and MigrateTo functions

### DIFF
--- a/sqltest/sqltest.go
+++ b/sqltest/sqltest.go
@@ -42,7 +42,7 @@ type Options struct {
 	SkipTeardown bool
 
 	// UseExisting database from connection instead of creating a temporary one.
-	// If set, the database isn't dropped after the tests.
+	// If set, the database isn't dropped during teardown / test cleanup.
 	UseExisting bool
 
 	// TemporaryDatabasePrefix for namespacing the temporary database name created for the test function.

--- a/sqltest/sqltest.go
+++ b/sqltest/sqltest.go
@@ -189,16 +189,12 @@ func (m *Migration) migrate(ctx context.Context, poolConn *pgxpool.Conn) (err er
 }
 
 // Teardown database after running the tests.
-// This function is registered by Setup to be called automatically by the testing package
-// during testing cleanup.
 //
-// In case this is not called, you can use the Force option to reset the database.
+// This function is registered by Setup to be called automatically by the testing package
+// during testing cleanup. Use the SkipTeardown option to disable this.
 func (m *Migration) Teardown(ctx context.Context) {
 	m.t.Helper()
 	m.t.Log("teardown PostgreSQL database")
-	if err := m.migrator.MigrateTo(ctx, 0); err != nil {
-		m.t.Fatalf("cannot tear down database migrations: %v", err)
-	}
 	m.pool.Close()
 
 	if !m.Options.UseExisting {

--- a/sqltest/sqltest_test.go
+++ b/sqltest/sqltest_test.go
@@ -101,7 +101,7 @@ func TestMigrationDirty(t *testing.T) {
 
 	// Prepare clean environment.
 	ctx := context.Background()
-	migration := sqltest.New(t, sqltest.Options{Force: *force, Path: "example/testdata/migrations", UseExisting: true})
+	migration := sqltest.New(t, sqltest.Options{Force: *force, Path: "example/testdata/migrations"})
 	conn := migration.Setup(ctx, "")
 
 	// Check if the migration version matches with the number of migration files.
@@ -129,7 +129,9 @@ func TestMigrationDirty(t *testing.T) {
 	if *force {
 		args = append(args, "-force")
 	}
-	out, err := exec.Command(os.Args[0], args...).CombinedOutput()
+	cmd := exec.Command(os.Args[0], args...)
+	cmd.Env = append(os.Environ(), "PGDATABASE="+sqltest.SQLTestName(t))
+	out, err := cmd.CombinedOutput()
 	if err == nil {
 		t.Error("expected command to fail")
 	}

--- a/sqltest/sqltest_test.go
+++ b/sqltest/sqltest_test.go
@@ -115,8 +115,8 @@ func TestMigrationDirty(t *testing.T) {
 			migrations++
 		}
 	}
-
-	// Let's update the schema_version to make it dirty, and verify we are unable to run the tests.
+	// Let's update the schema_version to make it ahead of the current version,
+	// and verify we are unable to run the tests.
 	if _, err := conn.Exec(context.Background(), "UPDATE schema_version SET version = $1 WHERE version = $2", migrations+1, migrations); err != nil {
 		t.Errorf("cannot update migration version: %q", err)
 	}
@@ -133,7 +133,7 @@ func TestMigrationDirty(t *testing.T) {
 	if err == nil {
 		t.Error("expected command to fail")
 	}
-	want := []byte(`database is dirty, please fix "schema_version" table manually or try -force`)
+	want := []byte(`database is dirty (current version is ahead of existing migrations), please fix "schema_version" table manually or try -force`)
 	if !bytes.Contains(out, want) {
 		t.Errorf("got %q, wanted %q", out, want)
 	}


### PR DESCRIPTION
- chore: improving docs.
- sqltest: consider a database as dirty only if its schema version is ahead of existing migrations.
- sqltest: don't run down migrations as part of teardown.
- sqltest: making TestMigrationDirty more robust.
- sqltest: adding SetupVersion and MigrateTo functions to enable migrating to specific versions.
